### PR TITLE
Conserve datatypes when writing the epw

### DIFF
--- a/epw/epw.py
+++ b/epw/epw.py
@@ -135,8 +135,5 @@ class epw():
                                     quotechar='"', quoting=csv.QUOTE_MINIMAL)
             for k,v in self.headers.items():
                 csvwriter.writerow([k]+v)
-            for row in self.dataframe.iterrows():
-                csvwriter.writerow(row[1].tolist())
-        
-        
-        
+            for row in self.dataframe.itertuples(index= False):
+                csvwriter.writerow(i for i in row)


### PR DESCRIPTION
Necessary when working with Radiance (epw2wea.exe)

e.g.:

2019.0,1.0,1.0,1.0, --> 2019,1,1,1,